### PR TITLE
Only use last_seen_at for replication key.

### DIFF
--- a/tap_swellrewards/streams.py
+++ b/tap_swellrewards/streams.py
@@ -26,8 +26,7 @@ class SwellRewardsStream:
         self.schema = self.load_schema()
         self.metadata = singer.metadata.get_standard_metadata(schema=self.load_schema(),
                                                               key_properties=self.key_properties,
-                                                              valid_replication_keys=self.valid_replication_keys,
-                                                              replication_method=self.replication_method)
+                                                              valid_replication_keys=self.valid_replication_keys)
 
         config_stream_params = config.get('streams', {}).get(self.tap_stream_id)
 
@@ -136,7 +135,6 @@ class CustomersStream(SwellRewardsStream):
     stream = 'customers'
     key_properties = ['email', 'last_seen_at']
     valid_replication_keys = ['last_seen_at']
-    replication_method = 'INCREMENTAL'
     valid_params = [
         'page',
         'per_page',

--- a/tap_swellrewards/streams.py
+++ b/tap_swellrewards/streams.py
@@ -135,7 +135,7 @@ class CustomersStream(SwellRewardsStream):
     tap_stream_id = 'customers'
     stream = 'customers'
     key_properties = ['email', 'last_seen_at']
-    valid_replication_keys = ['email', 'last_seen_at']
+    valid_replication_keys = ['last_seen_at']
     replication_method = 'INCREMENTAL'
     valid_params = [
         'page',


### PR DESCRIPTION
# Description of change
* Replication key should only use `last_seen_at` timestamp.
* Remove non-discoverable metadata.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
